### PR TITLE
Copter 3.4 mavlink planck cb heartbeat

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3117,8 +3117,8 @@
             <field type="float" name="xgyro">Angular speed around X axis rad/s</field>
             <field type="float" name="ygyro">Angular speed around Y axis rad/s</field>
             <field type="float" name="zgyro">Angular speed around Z axis rad/s</field>
-            <field type="double" name="lat">Latitude in degrees</field>
-            <field type="double" name="lon">Longitude in degrees</field>
+            <field type="float" name="lat">Latitude in degrees</field>
+            <field type="float" name="lon">Longitude in degrees</field>
             <field type="float" name="alt">Altitude in meters</field>
             <field type="float" name="std_dev_horz">Horizontal position standard deviation</field>
             <field type="float" name="std_dev_vert">Vertical position standard deviation</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3591,6 +3591,10 @@
            <field type="float" name="pitch">Pitch in degrees of the platform</field>
            <field type="float" name="yaw">Yaw in degrees of the platform</field>
         </message>
+        <message id="235" name="LANDING_PLATFORM_HEARTBEAT">
+           <description>The state of a landing platform, including WGS84 position and pose information (roll/pitch/yaw) in earth frame</description>
+           <field type="uint64_t" name="time_us">Wall-clock time in u-seconds of the landing platform</field>
+        </message>
         <message id="241" name="VIBRATION">
             <description>Vibration levels and accelerometer clipping</description>
             <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3117,8 +3117,8 @@
             <field type="float" name="xgyro">Angular speed around X axis rad/s</field>
             <field type="float" name="ygyro">Angular speed around Y axis rad/s</field>
             <field type="float" name="zgyro">Angular speed around Z axis rad/s</field>
-            <field type="float" name="lat">Latitude in degrees</field>
-            <field type="float" name="lon">Longitude in degrees</field>
+            <field type="double" name="lat">Latitude in degrees</field>
+            <field type="double" name="lon">Longitude in degrees</field>
             <field type="float" name="alt">Altitude in meters</field>
             <field type="float" name="std_dev_horz">Horizontal position standard deviation</field>
             <field type="float" name="std_dev_vert">Vertical position standard deviation</field>


### PR DESCRIPTION
Adding LANDING_PLATFORM_HEARTBEAT message

Related to: https://trello.com/c/yguYpdgY/437-failsafe-fixes-move-all-failsafe-logic-into-planck-ctrl-with-heartbeat-time-stamps-from-gcs-commbox