### PR TITLE
Continuous Integration Hotfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,14 @@ language: python
 python:
   - "2.7"
   - "3.5"
+  - "3.6"
+  
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
+
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libxml2-dev libxml2-utils

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.5"
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
Incorporate Python version support from `ArduPilot/mavlink`